### PR TITLE
Fix CSV header

### DIFF
--- a/Firmware/ChibiStudio/CAN-Logger/main.c
+++ b/Firmware/ChibiStudio/CAN-Logger/main.c
@@ -155,9 +155,9 @@ void start_log()
 
   file = fopen_(sLine, "a");
   if (bIncludeTimestamp)
-    strcpy(sLine, "Timestamp,ID,Data0,Data1,...\r\n");
+    strcpy(sLine, "Timestamp,ID,Data0,Data1,Data2,Data3,Data4,Data5,Data6,Data7\r\n");
   else
-    strcpy(sLine, "ID,Data0,Data1,...\r\n");
+    strcpy(sLine, "ID,Data0,Data1,Data2,Data3,Data4,Data5,Data6,Data7\r\n");
   fwrite_string(sLine);
   align_buffer();
   fwrite_(sd_buffer, 1, sd_buffer_length, file);


### PR DESCRIPTION
Spell out the column headers in CSV files, instead of "..."